### PR TITLE
Make WITW full-screen (no padding); fix up WITW references; make web pages use the same viewport settings

### DIFF
--- a/WITW/app/src/main/AndroidManifest.xml
+++ b/WITW/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <!--
 Copyright 2014 Google, Inc.
 
@@ -15,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.digitalartthingy.witw" >
 

--- a/WITW/app/src/main/AndroidManifest.xml
+++ b/WITW/app/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@ limitations under the License.
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
+++ b/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.digitalartthingy.witw;
 
 import android.app.Activity;

--- a/WITW/app/src/main/res/drawable/launch_screen.xml
+++ b/WITW/app/src/main/res/drawable/launch_screen.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-    <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-        <item>
-            <color android:color="@color/background_material_light"/>
-        </item>
-        <item>
-            <bitmap
-                android:src="@drawable/logo"
-                android:tileMode="disabled"
-                android:gravity="center"/>
-        </item>
-    </layer-list>
+<!--
+     Copyright (C) 2017 Digital Art Thingy Inc.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <color android:color="@color/background_material_light"/>
+    </item>
+    <item>
+        <bitmap
+            android:src="@drawable/logo"
+            android:tileMode="disabled"
+            android:gravity="center"/>
+    </item>
+</layer-list>

--- a/WITW/app/src/main/res/layout/main_activity.xml
+++ b/WITW/app/src/main/res/layout/main_activity.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
      Copyright (C) 2014 Google, Inc.
 
      Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/WITW/app/src/main/res/layout/main_activity.xml
+++ b/WITW/app/src/main/res/layout/main_activity.xml
@@ -19,10 +19,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
     android:keepScreenOn="true">
 
     <android.support.v7.widget.Toolbar

--- a/WITW/app/src/main/res/menu/main_menu.xml
+++ b/WITW/app/src/main/res/menu/main_menu.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2017 Digital Art Thingy Inc.
+-->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/WITW/app/src/main/res/values/dimens.xml
+++ b/WITW/app/src/main/res/values/dimens.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2017 Digital Art Thingy Inc.
+-->
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>

--- a/WITW/app/src/main/res/values/strings.xml
+++ b/WITW/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <resources>
-    <string name="app_name">Where in the world is ...</string>
+    <string name="app_name">Where in the world ...</string>
     <string name="latitude_label">Latitude</string>
     <string name="longitude_label">Longitude</string>
     <string name="last_update_time_label">Last location update time</string>

--- a/WITW/app/src/main/res/values/styles.xml
+++ b/WITW/app/src/main/res/values/styles.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2017 Digital Art Thingy Inc.
+-->
 <resources>
     <style name="Theme.WITW" parent="Theme.AppCompat.Light">
         <item name="android:windowBackground">@drawable/launch_screen</item>

--- a/docs/HappyBirthday.html
+++ b/docs/HappyBirthday.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,user-scalable=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="Digital Art Thingy Inc. explores cross platform development opportunities on the desktop and mobile devices.">
     <meta name="author" content="Digital Art Thingy Inc.">

--- a/docs/WITW.html
+++ b/docs/WITW.html
@@ -40,7 +40,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="#">Where in the world is ...</a>
+          <a class="navbar-brand" href="#">Where in the world ...</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav">

--- a/docs/WITW.html
+++ b/docs/WITW.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,user-scalable=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="Digital Art Thingy Inc. explores cross platform development opportunities on the desktop and mobile devices.">
     <meta name="author" content="Digital Art Thingy Inc.">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,user-scalable=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="Digital Art Thingy Inc. explores cross platform development opportunities on the desktop and mobile devices.">
     <meta name="author" content="Digital Art Thingy Inc.">

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Projects <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                        <li><a href="HappyBirthday.html">Happy Birthday</a></li>
-                       <li><a href="WITW.html">Where in the world is ...</a></li>
+                       <li><a href="WITW.html">Where in the world ...</a></li>
                     </ul>
                   </li>
                   <li><a href="#">Contact</a></li>

--- a/docs/legal/privacy.html
+++ b/docs/legal/privacy.html
@@ -23,7 +23,7 @@ THE SOFTWARE.-->
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1,minimum-scale=1.0,user-scalable=no">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,user-scalable=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="Privacy Policy - Where in the world ...">
     <meta name="author" content="Digital Art Thingy Inc.">


### PR DESCRIPTION
I wanted to fix up a few small things before the long July 4th break. It snowballed as I found other things I wanted to make more consistent.

CHANGES:
1. Removed the padding around the main activity so the app is truly full-screen
2. I updated the HTML pages so that they all had the same viewport settings; didn't like the magnifying glass popping up on some pages
3. Updated AndroidManifest suppressing the behavior where the app would restart the activity if you change orientation or screen size