### PR TITLE
Reset default zoom level to street level when MyLocation button is pressed

### DIFF
--- a/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
+++ b/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
@@ -232,12 +232,12 @@ public class MainActivity extends AppCompatActivity implements
                 }
             });
 
-            // Reset the zoom level to closer to street-level when the MyLocation button is clicked
+            // Reset the zoom level to street level when the MyLocation button is clicked
             mGoogleMap.setOnMyLocationButtonClickListener(new GoogleMap.OnMyLocationButtonClickListener() {
                 @Override
                 public boolean onMyLocationButtonClick() {
                     mZoomLevel = DEFAULT_ZOOM_LEVEL_PREFERENCE;
-                    return true;
+                    return false;
                 }
             });
         }

--- a/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
+++ b/WITW/app/src/main/java/com/digitalartthingy/witw/MainActivity.java
@@ -65,8 +65,8 @@ public class MainActivity extends AppCompatActivity implements
     /**
      * The zoom level needs to be remembered if the user decides to change it (default 15.0f - street level)
      */
-    private static final float MAX_ZOOM_LEVEL_PREFERENCE = 15.0f;
-    private static float mZoomLevel = MAX_ZOOM_LEVEL_PREFERENCE;
+    private static final float DEFAULT_ZOOM_LEVEL_PREFERENCE = 15.0f;
+    private static float mZoomLevel = DEFAULT_ZOOM_LEVEL_PREFERENCE;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -229,6 +229,15 @@ public class MainActivity extends AppCompatActivity implements
                     if (lastKnownLocation != null) {
                         mGoogleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(lastKnownLocation.getLatitude(), lastKnownLocation.getLongitude()), mZoomLevel));
                     }
+                }
+            });
+
+            // Reset the zoom level to closer to street-level when the MyLocation button is clicked
+            mGoogleMap.setOnMyLocationButtonClickListener(new GoogleMap.OnMyLocationButtonClickListener() {
+                @Override
+                public boolean onMyLocationButtonClick() {
+                    mZoomLevel = DEFAULT_ZOOM_LEVEL_PREFERENCE;
+                    return true;
                 }
             });
         }


### PR DESCRIPTION
Fix bug where if you didn't get an accurate location, you'd be left at the global zoom level. Even if the GPS signal was restored, the user would be forced to zoom in via the anti-pinch gesture because we only remember the last zoom level.

With this change, the MyLocation button will reset the zoom level to street level each time. I think that makes more sense for users.
