### PR TITLE
Cosmetic updates -- CSS and splash screen -- identified during beta release

### DIFF
--- a/WITW/app/build.gradle
+++ b/WITW/app/build.gradle
@@ -25,7 +25,7 @@ android {
         applicationId "com.digitalartthingy.witw"
         minSdkVersion 11
         targetSdkVersion 22
-        versionCode 5
+        versionCode 6
         versionName "Beta release of Where in the world ..."
         resValue "string", "google_maps_key", (project.findProperty("GOOGLE_MAPS_API_KEY") ?: "")
     }

--- a/WITW/app/src/main/res/layout/main_activity.xml
+++ b/WITW/app/src/main/res/layout/main_activity.xml
@@ -19,6 +19,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:scaleType="fitCenter"
     android:keepScreenOn="true">
 
     <android.support.v7.widget.Toolbar

--- a/docs/cover.css
+++ b/docs/cover.css
@@ -26,11 +26,11 @@ a:hover {
 
 html,
 body {
-  height: 100%; 
+  height: 100%;
   background-image: url(images/digital_art_background.jpg);
   background-repeat: no-repeat;
   background-position:top center;
-  background-size: cover;  
+  background-size: cover;
 }
 body {
   color: #fff;
@@ -101,41 +101,41 @@ body {
 @media (min-width: 768px) {
   .masthead-brand {
     float: left;
-    color: #2bbf29;	
+    color: #2bbf29;
   }
   .masthead-nav {
     float: right;
   }
-  
+
   .cover-heading {
-    color: #2bbf29;	  
+    color: #2bbf29;
   }
-  
+
   .btn-default {
-	text-shadow: 0 1px 0 #fff;
-	background-image: -webkit-linear-gradient(top,#166a14 0,#2bbf29 100%);
-	background-image: -o-linear-gradient(top,#166a14 0,#2bbf29 100%);
-	background-image: -webkit-gradient(linear,left top,left bottom,from(#166a14),to(#2bbf29));
-	background-image: linear-gradient(to bottom,#166a14 0,#2bbf29 100%);
-	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff166a14', endColorstr='#ff2bbf29', GradientType=0);
-	filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
-	background-repeat: repeat-x;
+    text-shadow: 0 1px 0 #fff;
+    background-image: -webkit-linear-gradient(top,#166a14 0,#2bbf29 100%);
+    background-image: -o-linear-gradient(top,#166a14 0,#2bbf29 100%);
+    background-image: -webkit-gradient(linear,left top,left bottom,from(#166a14),to(#2bbf29));
+    background-image: linear-gradient(to bottom,#166a14 0,#2bbf29 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff166a14', endColorstr='#ff2bbf29', GradientType=0);
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+    background-repeat: repeat-x;
     text-shadow: none;
     color: #333;
     border: 1px solid #166a14;
   }
-  
+
   .btn-default:focus, .btn-default:hover {
-  	background-position: 0 0;
-	background-image: #166a14;
-	background-image: -webkit-linear-gradient(top,#166a14 0,#166a14 100%);
-	background-image: -o-linear-gradient(top,#166a14 0,#166a14 100%);
-	background-image: -webkit-gradient(linear,left top,left bottom,from(#166a14),to(#166a14));
-	background-image: linear-gradient(to bottom,#166a14 0,#166a14 100%);
-	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff166a14', endColorstr='#ff166a14', GradientType=0);
-	filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);	
+    background-position: 0 0;
+    background-image: #166a14;
+    background-image: -webkit-linear-gradient(top,#166a14 0,#166a14 100%);
+    background-image: -o-linear-gradient(top,#166a14 0,#166a14 100%);
+    background-image: -webkit-gradient(linear,left top,left bottom,from(#166a14),to(#166a14));
+    background-image: linear-gradient(to bottom,#166a14 0,#166a14 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff166a14', endColorstr='#ff166a14', GradientType=0);
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
     color: #fff;
-    border: 1px solid #2bbf29;	
+    border: 1px solid #2bbf29;
   }
 }
 

--- a/docs/cover.css
+++ b/docs/cover.css
@@ -31,8 +31,6 @@ body {
   background-repeat: no-repeat;
   background-position:top center;
   background-size: cover;
-}
-body {
   color: #fff;
   text-align: center;
   text-shadow: 0 1px 3px rgba(0,0,0,.5);

--- a/docs/legal/assets/css/style.css
+++ b/docs/legal/assets/css/style.css
@@ -1,1 +1,205 @@
-.mediumFont{font-weight:500}b,strong{font-weight:700}a{color:#355ebf}a:focus{outline:0}i{font-style:italic}.main{text-align:center;font-size:17px;color:#404040}.header{height:44px;line-height:44px;background-color:#f3f8fe;position:fixed;width:100%;top:0;z-index:2}#backLink{background:url(../img/btn_back_@2x.png) no-repeat 0 center;background-size:14px;padding-left:22px;position:absolute;left:15px}.contentDetails,.headerContent,.footerContent{max-width:768px;margin-left:auto;margin-right:auto;padding-left:15px;padding-right:15px;position:relative}.contentDetails{padding:15px;margin-top:44px;margin-bottom:84px}.contentDetails>*{padding-left:15px;padding-right:15px}.contentDetails .nav-tabs{border-bottom:1px solid #ccc;padding-left:0;padding-right:0}.tab-content{padding-left:0;padding-right:0;font-size:15px;border-top:3px solid #f1f1f1}.tab-content .title{font-size:17px;font-weight:bold;border-bottom:1px solid #ccc;padding-bottom:10px}.headerImage,.privacyMessage{margin-bottom:20px}.headerImage{background:no-repeat center;background-size:contain;height:44px}.contentItem{text-align:left;background:url(../img/icn_check_collected_@2x.png) no-repeat 0 22px;background-size:15px;padding:20px 32px 20px 25px;border-bottom:1px solid #dcdcdc;position:relative;cursor:pointer}.notCollected .contentItem{background-image:url(../img/icn_not_collected_@2x.png)}.notCollected{margin-top:20px}.contentItem .itemHeader{padding-bottom:5px;font-weight:bold}.contentItem p{margin:0}.contentItem .itemDescription{padding-bottom:10px}.itemDetailToggleLink{position:absolute;right:0;top:50%;margin-top:-15px;width:30px;height:30px;background:url(../img/btn_expand_@2x.png) no-repeat right;background-size:15px}.contentItem .itemDetails{max-height:0;overflow:hidden;font-size:14px;color:#969696;-webkit-transform:translateZ(0);-webkit-transition:max-height 150ms;-moz-transition:max-height 150ms;-ms-transition:max-height 150ms;-o-transition:max-height 150ms;transition:max-height 150ms}.contentItem.expanded .itemDetails{max-height:80px}.contentItem.expanded .itemDetails.longText{max-height:130px}.contentItem.expanded .itemDetailToggleLink{background-image:url(../img/btn_collapse_@2x.png)}.footer{background-color:#f1f1f1;position:fixed;bottom:0;width:100%;z-index:2;-webkit-backface-visibility:hidden}.footer .footerContent{height:44px;line-height:44px}.spacer{height:3px;background-color:#f1f1f1}.nav-tabs>li,.nav-pills>li{width:50%;margin-bottom:0}.nav-tabs>li.separator{width:1px;height:35px;margin-top:5px;border-left:1px dotted #969696;position:absolute;left:50%;z-index:1}.nav-tabs,.nav-pills{text-align:center}.contentDetails .nav-tabs>li.active{border-bottom:4px solid #264d9c}.contentDetails .nav-tabs>li>a{padding:10px 5px;margin-right:0}.contentDetails .nav-tabs>li.active>a{color:#404040;border:0;font-weight:bold}
+/*
+ Copyright (c) 2014 Intuit, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+.mediumFont {
+  font-weight: 500;
+}
+b,
+strong {
+  font-weight: 700;
+}
+a {
+  color: #355ebf;
+}
+a:focus {
+  outline: none;
+}
+i {
+  font-style: italic;
+}
+.main {
+  text-align: center;
+  font-size: 17px;
+  color: #404040;
+}
+.header {
+  height: 44px;
+  line-height: 44px;
+  background-color: #F3F8FE;
+  position: fixed;
+  width: 100%;
+  top: 0;
+  z-index: 2;
+}
+#backLink {
+  background: url(../img/btn_back_@2x.png) no-repeat 0 center;
+  background-size: 14px;
+  padding-left: 22px;
+  position: absolute;
+  left: 15px;
+}
+.contentDetails,
+.headerContent,
+.footerContent {
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 15px;
+  padding-right: 15px;
+  position: relative;
+}
+.contentDetails {
+  padding: 15px;
+  margin-top: 44px;
+  margin-bottom: 84px;
+}
+.contentDetails > * {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.contentDetails .nav-tabs {
+  border-bottom: 1px solid #cccccc;
+  padding-left: 0;
+  padding-right: 0;
+}
+.tab-content {
+  padding-left: 0;
+  padding-right: 0;
+  font-size: 15px;
+  border-top: 3px solid #f1f1f1;
+}
+.tab-content .title {
+  font-size: 17px;
+  font-weight: bold;
+  border-bottom: 1px solid #cccccc;
+  padding-bottom: 10px;
+}
+.headerImage,
+.privacyMessage {
+  margin-bottom: 20px;
+}
+.headerImage {
+  background: no-repeat center;
+  background-size: contain;
+}
+.contentItem {
+  text-align: left;
+  background: url(../img/icn_check_collected_@2x.png) no-repeat 0 22px;
+  background-size: 15px;
+  padding: 20px 32px 20px 25px;
+  border-bottom: 1px solid #dcdcdc;
+  position: relative;
+  cursor: pointer;
+}
+.notCollected .contentItem {
+  background-image: url(../img/icn_not_collected_@2x.png);
+}
+.notCollected {
+  margin-top: 20px;
+}
+.contentItem .itemHeader {
+  padding-bottom: 5px;
+  font-weight: bold;
+}
+.contentItem p {
+  margin: 0;
+}
+.contentItem .itemDescription {
+  padding-bottom: 10px;
+}
+.itemDetailToggleLink {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  margin-top: -15px;
+  width: 30px;
+  height: 30px;
+  background: url(../img/btn_expand_@2x.png) no-repeat right;
+  background-size: 15px;
+}
+.contentItem .itemDetails {
+  max-height: 0;
+  overflow: hidden;
+  font-size: 14px;
+  color: #969696;
+  -webkit-transform: translateZ(0);
+  -webkit-transition: max-height 150ms;
+  -moz-transition: max-height 150ms;
+  -ms-transition: max-height 150ms;
+  -o-transition: max-height 150ms;
+  transition: max-height 150ms;
+}
+.contentItem.expanded .itemDetails {
+  max-height: 80px;
+}
+.contentItem.expanded .itemDetails.longText {
+  max-height: 130px;
+}
+.contentItem.expanded .itemDetailToggleLink {
+  background-image: url(../img/btn_collapse_@2x.png);
+}
+.footer {
+  background-color: #F1F1F1;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  z-index: 2;
+  -webkit-backface-visibility: hidden;
+}
+.footer .footerContent {
+  height: 44px;
+  line-height: 44px;
+}
+.spacer {
+  height: 3px;
+  background-color: #f1f1f1;
+}
+/* Bootstrap overrides */
+.nav-tabs > li,
+.nav-pills > li {
+  width: 50%;
+  margin-bottom: 0;
+}
+.nav-tabs > li.separator {
+  width: 1px;
+  height: 35px;
+  margin-top: 5px;
+  border-left: 1px dotted #969696;
+  position: absolute;
+  left: 50%;
+  z-index: 1;
+}
+.nav-tabs,
+.nav-pills {
+  text-align: center;
+}
+.contentDetails .nav-tabs > li.active {
+  border-bottom: 4px solid #264D9C;
+}
+.contentDetails .nav-tabs > li > a {
+  padding: 10px 5px;
+  margin-right: 0;
+}
+.contentDetails .nav-tabs > li.active > a {
+  color: #404040;
+  border: none;
+  font-weight: bold;
+}

--- a/docs/legal/assets/css/style.less
+++ b/docs/legal/assets/css/style.less
@@ -101,7 +101,6 @@ i { font-style: italic; }
 .headerImage {
     background: no-repeat center;
     background-size: contain;
-    height: 44px;
 }
 
 .contentItem {

--- a/docs/legal/privacy.html
+++ b/docs/legal/privacy.html
@@ -30,6 +30,12 @@ THE SOFTWARE.-->
     <link rel="icon" href="favicon.ico">
     <title>Privacy Policy</title>
     <link href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Bootstrap core CSS -->
+    <link href="../css/bootstrap.min.css" rel="stylesheet">
+    <link href="../css/bootstrap-theme.min.css" rel="stylesheet">
+
+    <!-- Theme for this page -->
     <link rel="stylesheet" href="assets/css/style.css">
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,51 +1,51 @@
-body { 
-	padding-top: 70px; 
-	padding-bottom: 30px;
+body {
+    padding-top: 70px;
+    padding-bottom: 30px;
 }
-.theme-dropdown .dropdown-menu { 
-	position: static; 
-	display: block; 
-	margin-bottom: 20px;
+.theme-dropdown .dropdown-menu {
+    position: static;
+    display: block;
+    margin-bottom: 20px;
 }
-.theme-showcase > p > .btn { 
-	margin: 5px 0;
+.theme-showcase > p > .btn {
+    margin: 5px 0;
 }
-.theme-showcase .navbar .container { 
-	width: auto;
+.theme-showcase .navbar .container {
+    width: auto;
 }
 
-.main_container { 
-	padding: 0;
+.main_container {
+    padding: 0;
 }
-.main_container .focus_block img { 
-	width: 100%;
+.main_container .focus_block img {
+    width: 100%;
 }
-.main_container .jumbotron .image_container { 
-	text-align: center; 
-	width: 100%;
+.main_container .jumbotron .image_container {
+    text-align: center;
+    width: 100%;
 }
-.main_container .jumbotron .image_container img { 
-	max-width:480px; 
-	width: 100%;
+.main_container .jumbotron .image_container img {
+    max-width:480px;
+    width: 100%;
 }
-.main_container ul { 
-	padding: 0 0 0 20px; 
-	list-style: none; 
-	margin: 30px 0;
+.main_container ul {
+    padding: 0 0 0 20px;
+    list-style: none;
+    margin: 30px 0;
 }
-.main_container ul li { 
-	background: url(images/list_button.png) no-repeat 0 3px; 
-	width: auto; 
-	height: 20px; 
-	margin-left: -20px; 
-	padding-left: 30px; 
-	font-size: 18px; 
-	margin-bottom: 15px; 
-	display: table;
+.main_container ul li {
+    background: url(images/list_button.png) no-repeat 0 3px;
+    width: auto;
+    height: 20px;
+    margin-left: -20px;
+    padding-left: 30px;
+    font-size: 18px;
+    margin-bottom: 15px;
+    display: table;
 }
 
 @media screen and (max-width: 768px) {
-    .jumbotron p, .main_container ul li { 
-		font-size: 1.5rem;
-	}
+    .jumbotron p, .main_container ul li {
+        font-size: 1.5rem;
+    }
 }

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,7 +1,3 @@
-body {
-    padding-top: 70px;
-    padding-bottom: 30px;
-}
 .theme-dropdown .dropdown-menu {
     position: static;
     display: block;


### PR DESCRIPTION
CHANGES:
1. Removed fixed height in headerImage privacy's CSS
2. Removed fixed body padding around project theme's CSS
3. Applied scaleType = fitCenter to center splash screen image
4. Tabs --> spaces
